### PR TITLE
refactor(platform): replace inline animations with usePageTransition hook (5 pages)

### DIFF
--- a/apps/web/src/app/(platform)/certificates/page.tsx
+++ b/apps/web/src/app/(platform)/certificates/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { usePageTransition } from "@/hooks/use-page-transition"
 import {
   Award,
   Download,
@@ -97,24 +98,9 @@ const walletInfo = {
   totalValue: "0.45 MATIC (~€0.38)"
 }
 
-const staggerContainer = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1 }
-  }
-}
-
-const fadeInUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.5, ease: "easeOut" as const }
-  }
-}
-
 export default function CertificatesPage() {
+  const { variants, createStaggerContainer } = usePageTransition()
+  const staggerContainer = createStaggerContainer(0.1)
   const [copiedAddress, setCopiedAddress] = useState(false)
 
   const copyAddress = () => {
@@ -226,7 +212,7 @@ export default function CertificatesPage() {
               className="grid md:grid-cols-2 gap-6"
             >
               {certificates.map((cert) => (
-                <motion.div key={cert.id} variants={fadeInUp}>
+                <motion.div key={cert.id} variants={variants.fadeInUp}>
                   <Card className={`border-2 hover:shadow-xl transition-all h-full ${
                     cert.status === "minted"
                       ? "hover:border-[hsl(var(--indigo)_/_0.3)]"
@@ -344,7 +330,7 @@ export default function CertificatesPage() {
               className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4"
             >
               {badges.map((badge) => (
-                <motion.div key={badge.id} variants={fadeInUp}>
+                <motion.div key={badge.id} variants={variants.fadeInUp}>
                   <Card className={`border-2 text-center transition-all ${
                     badge.earned
                       ? "hover:border-[hsl(var(--amber)_/_0.3)] hover:shadow-lg cursor-pointer"

--- a/apps/web/src/app/(platform)/community/page.tsx
+++ b/apps/web/src/app/(platform)/community/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Input } from "@/components/ui/input"
+import { usePageTransition } from "@/hooks/use-page-transition"
 import {
   Users,
   MessageSquare,
@@ -156,24 +157,9 @@ const topContributors = [
   { name: "Marco Bianchi", avatar: "MB", posts: 54, likes: 312 }
 ]
 
-const staggerContainer = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1 }
-  }
-}
-
-const fadeInUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.5, ease: "easeOut" as const }
-  }
-}
-
 export default function CommunityPage() {
+  const { variants, createStaggerContainer } = usePageTransition()
+  const staggerContainer = createStaggerContainer(0.1)
   const [activeCategory, setActiveCategory] = useState("all")
   const [searchQuery, setSearchQuery] = useState("")
   const [likedPosts, setLikedPosts] = useState<string[]>([])
@@ -272,7 +258,7 @@ export default function CommunityPage() {
               className="space-y-4"
             >
               {filteredDiscussions.map((discussion) => (
-                <motion.div key={discussion.id} variants={fadeInUp}>
+                <motion.div key={discussion.id} variants={variants.fadeInUp}>
                   <Card className={`border-2 hover:border-[hsl(var(--indigo)_/_0.3)] hover:shadow-lg transition-all ${
                     discussion.isPinned ? "border-[hsl(var(--amber)_/_0.3)] bg-[hsl(var(--amber)_/_0.02)]" : ""
                   }`}>

--- a/apps/web/src/app/(platform)/my-courses/page.tsx
+++ b/apps/web/src/app/(platform)/my-courses/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { usePageTransition } from "@/hooks/use-page-transition"
 import {
   BookOpen,
   Clock,
@@ -22,15 +23,6 @@ import {
   ExternalLink,
   Sparkles
 } from "lucide-react"
-
-const fadeInUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.5 }
-  }
-}
 
 const courses = [
   {
@@ -121,7 +113,7 @@ const stats = [
   }
 ]
 
-function CourseCard({ course }: { course: typeof courses[0] }) {
+function CourseCard({ course, fadeInUp }: { course: typeof courses[0]; fadeInUp: any }) {
   const statusConfig = {
     active: {
       label: "In Corso",
@@ -298,6 +290,7 @@ function CourseCard({ course }: { course: typeof courses[0] }) {
 }
 
 export default function MyCoursesPage() {
+  const { variants } = usePageTransition()
   const [activeTab, setActiveTab] = useState("all")
 
   const filteredCourses = courses.filter((course) => {
@@ -404,7 +397,7 @@ export default function MyCoursesPage() {
                 ) : (
                   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {filteredCourses.map((course) => (
-                      <CourseCard key={course.id} course={course} />
+                      <CourseCard key={course.id} course={course} fadeInUp={variants.fadeInUp} />
                     ))}
                   </div>
                 )}

--- a/apps/web/src/app/(platform)/placement/page.tsx
+++ b/apps/web/src/app/(platform)/placement/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { usePageTransition } from "@/hooks/use-page-transition"
 import {
   Briefcase,
   TrendingUp,
@@ -180,24 +181,9 @@ const interviewPrep = [
   }
 ]
 
-const staggerContainer = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1 }
-  }
-}
-
-const fadeInUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.5, ease: "easeOut" as const }
-  }
-}
-
 export default function PlacementPage() {
+  const { variants, createStaggerContainer } = usePageTransition()
+  const staggerContainer = createStaggerContainer(0.1)
   const [savedJobs, setSavedJobs] = useState<string[]>(["2"])
 
   const toggleSave = (jobId: string) => {
@@ -356,7 +342,7 @@ export default function PlacementPage() {
               </div>
 
               {recommendedJobs.map((job) => (
-                <motion.div key={job.id} variants={fadeInUp}>
+                <motion.div key={job.id} variants={variants.fadeInUp}>
                   <Card className="border-2 hover:border-[hsl(var(--indigo)_/_0.3)] hover:shadow-lg transition-all">
                     <CardContent className="p-6">
                       <div className="flex items-start gap-6">
@@ -464,7 +450,7 @@ export default function PlacementPage() {
               </h2>
 
               {applications.map((app) => (
-                <motion.div key={app.id} variants={fadeInUp}>
+                <motion.div key={app.id} variants={variants.fadeInUp}>
                   <Card className="border-2">
                     <CardContent className="p-6">
                       <div className="flex items-center justify-between mb-4">
@@ -553,7 +539,7 @@ export default function PlacementPage() {
 
               <div className="grid md:grid-cols-2 gap-4">
                 {interviewPrep.map((item) => (
-                  <motion.div key={item.id} variants={fadeInUp}>
+                  <motion.div key={item.id} variants={variants.fadeInUp}>
                     <Card className={`border-2 ${item.completed ? "opacity-75" : "hover:border-[hsl(var(--indigo)_/_0.3)]"}`}>
                       <CardContent className="p-6">
                         <div className="flex items-start justify-between mb-4">

--- a/apps/web/src/app/(platform)/profile/page.tsx
+++ b/apps/web/src/app/(platform)/profile/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { usePageTransition } from "@/hooks/use-page-transition"
 import {
   Settings,
   Award,
@@ -174,24 +175,9 @@ const certificates = [
   }
 ]
 
-const staggerContainer = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1 }
-  }
-}
-
-const fadeInUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.5, ease: "easeOut" as const }
-  }
-}
-
 export default function ProfilePage() {
+  const { variants, createStaggerContainer } = usePageTransition()
+  const staggerContainer = createStaggerContainer(0.1)
   const [activeTab, setActiveTab] = useState("overview")
 
   return (
@@ -317,7 +303,7 @@ export default function ProfilePage() {
           ].map((stat, index) => {
             const Icon = stat.icon
             return (
-              <motion.div key={stat.label} variants={fadeInUp}>
+              <motion.div key={stat.label} variants={variants.fadeInUp}>
                 <Card className="border-2 hover:border-[hsl(var(--indigo)_/_0.3)] transition-all">
                   <CardContent className="p-4 text-center">
                     <div className={`inline-flex p-2 rounded-lg bg-[hsl(var(--${stat.color})_/_0.1)] mb-2`}>
@@ -366,7 +352,7 @@ export default function ProfilePage() {
               className="grid md:grid-cols-2 gap-6"
             >
               {portfolioProjects.map((project) => (
-                <motion.div key={project.id} variants={fadeInUp}>
+                <motion.div key={project.id} variants={variants.fadeInUp}>
                   <Card className="border-2 hover:border-[hsl(var(--indigo)_/_0.3)] hover:shadow-xl transition-all group h-full">
                     {/* Project Thumbnail */}
                     <div className="relative h-48 bg-gradient-to-br from-[hsl(var(--indigo)_/_0.1)] to-[hsl(var(--amber)_/_0.1)] overflow-hidden">


### PR DESCRIPTION
## Summary
Applica `usePageTransition` hook a 5 pagine platform per consistency con le marketing pages, rimuovendo animation variants inline duplicate.

**Section 4 - Platform Pages Assessment:** Quick win per ridurre duplicazione e standardizzare animations.

## Changes

### Pages Refactored (5/12 platform pages)

**1. `(platform)/community/page.tsx`** (488 LOC)
- ✅ Rimosso `fadeInUp` + `staggerContainer` inline
- ✅ Aggiunto `usePageTransition` hook + `createStaggerContainer`

**2. `(platform)/placement/page.tsx`** (604 LOC)
- ✅ Rimosso `fadeInUp` + `staggerContainer` inline
- ✅ Aggiunto `usePageTransition` hook + `createStaggerContainer`

**3. `(platform)/profile/page.tsx`** (570 LOC)
- ✅ Rimosso `fadeInUp` + `staggerContainer` inline
- ✅ Aggiunto `usePageTransition` hook + `createStaggerContainer`

**4. `(platform)/my-courses/page.tsx`** (455 LOC)
- ✅ Rimosso `fadeInUp` inline
- ✅ Aggiunto `usePageTransition` hook
- ✅ Passato `fadeInUp` come prop a `CourseCard` component

**5. `(platform)/certificates/page.tsx`** (433 LOC)
- ✅ Rimosso `fadeInUp` + `staggerContainer` inline
- ✅ Aggiunto `usePageTransition` hook + `createStaggerContainer`

## Metrics

- **Pages refactored:** 5/12 (42% platform pages)
- **LOC processed:** ~2,550
- **LOC removed:** 87
- **LOC added:** 24
- **Net reduction:** -63 LOC (-2.5%)
- **Type-check:** ✅ Passed

## Remaining Platform Pages (7/12)

Le seguenti pagine NON hanno variants inline e non richiedono questo refactoring:
- dashboard (242 LOC) - già ben componentizzato
- settings (153 LOC) - piccolo, nessuna animation
- ai-tutor (438 LOC)
- onboarding (543 LOC)
- pre-assessment (466 LOC)
- lessons/[id] (460 LOC)
- lessons/1 (543 LOC)

## Testing

```bash
pnpm turbo run type-check --filter=@edu-hub/web  # ✅ Passed
```

## Next Steps - Section 4

**Opzioni per completare Section 4:**
1. ✅ **Fatto**: Standardizzare animations (questo PR)
2. **Da valutare**: Analizzare se ci sono altri pattern comuni da estrarre nelle 12 pagine platform
3. **Alternative**: Procedere con Section 3 (Auth Flow) se Section 4 è considerata completa

---

**Related:** #5 (Section 4 - Platform Pages Assessment)