### PR TITLE
feat: migrate design system to B&W sketchpad style

### DIFF
--- a/apps/web/src/app/(platform)/dashboard/page.tsx
+++ b/apps/web/src/app/(platform)/dashboard/page.tsx
@@ -135,10 +135,10 @@ const upcomingLessons = [
 ]
 
 const skillsProgress = [
-  { name: "User Research", level: 45, color: "from-indigo-500 to-purple-600" },
-  { name: "Wireframing", level: 30, color: "from-amber-500 to-orange-600" },
-  { name: "Prototyping", level: 15, color: "from-emerald-500 to-teal-600" },
-  { name: "Visual Design", level: 10, color: "from-rose-500 to-pink-600" }
+  { name: "User Research", level: 45, color: "from-neutral-800 to-neutral-600" },
+  { name: "Wireframing", level: 30, color: "from-neutral-600 to-neutral-400" },
+  { name: "Prototyping", level: 15, color: "from-neutral-500 to-neutral-300" },
+  { name: "Visual Design", level: 10, color: "from-neutral-400 to-neutral-200" }
 ]
 
 const communityActivity = [

--- a/apps/web/src/app/(platform)/lessons/[id]/page.tsx
+++ b/apps/web/src/app/(platform)/lessons/[id]/page.tsx
@@ -33,7 +33,7 @@ export default function LessonPage() {
   const [currentSection, setCurrentSection] = useState(1)
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-muted">
       {/* Top Navigation */}
       <div className="bg-white border-b sticky top-24 z-10 shadow-sm">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between flex-wrap gap-4">
@@ -45,7 +45,7 @@ export default function LessonPage() {
           <div className="flex-1 mx-8 min-w-[200px]">
             <div className="flex items-center justify-between text-sm mb-2">
               <span className="font-medium">Lesson 1.2: Design Thinking Process</span>
-              <span className="text-gray-600">{progress}%</span>
+              <span className="text-muted-foreground">{progress}%</span>
             </div>
             <Progress value={progress} className="h-2" />
           </div>
@@ -72,7 +72,7 @@ export default function LessonPage() {
               <Badge variant="outline">60 min</Badge>
               <Badge variant="outline">UX/UI Master</Badge>
             </div>
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <h1 className="text-3xl md:text-4xl font-bold text-foreground">
               🎓 Lesson 1.2: Design Thinking Process
             </h1>
           </div>
@@ -81,7 +81,7 @@ export default function LessonPage() {
           <Card className="mb-6">
             <CardContent className="p-6">
               <h3 className="font-semibold mb-4">🎛️ Preferenze Contenuto</h3>
-              <p className="text-sm text-gray-600 mb-4">
+              <p className="text-sm text-muted-foreground mb-4">
                 Come vuoi fruire questa lezione? Scegli il formato che preferisci.
               </p>
 
@@ -144,12 +144,12 @@ export default function LessonPage() {
 
           {/* Accessibility Banner */}
           {accessibilityMode && (
-            <Card className="mb-6 border-blue-200 bg-blue-50">
+            <Card className="mb-6 border-border bg-muted">
               <CardContent className="p-4">
-                <h4 className="font-semibold text-blue-900 mb-2">
+                <h4 className="font-semibold text-foreground mb-2">
                   ♿ Modalità Accessibilità Attiva
                 </h4>
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-sm text-blue-800">
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-sm text-foreground">
                   <div>✓ Font leggibile</div>
                   <div>✓ Spaziatura 2x</div>
                   <div>✓ Alto contrasto</div>
@@ -165,30 +165,30 @@ export default function LessonPage() {
           <Card className="mb-6">
             <CardContent className={`p-8 ${accessibilityMode ? 'leading-relaxed' : ''}`}>
               <div className="mb-6 text-center">
-                <Badge className="bg-gradient-to-r from-purple-500 to-pink-500 text-white">
+                <Badge className="bg-foreground text-background">
                   Sezione {currentSection} di 4
                 </Badge>
               </div>
 
-              <h2 className={`text-2xl font-bold text-gray-900 mb-6 text-center ${accessibilityMode ? 'text-3xl mb-8' : ''}`}>
+              <h2 className={`text-2xl font-bold text-foreground mb-6 text-center ${accessibilityMode ? 'text-3xl mb-8' : ''}`}>
                 Introduzione al Design Thinking
               </h2>
 
               {/* Video Player */}
               {(contentMode === "video-text" || contentMode === "video") && (
                 <div className="mb-8">
-                  <div className="aspect-video bg-gray-900 rounded-lg relative overflow-hidden shadow-lg">
+                  <div className="aspect-video bg-foreground rounded-lg relative overflow-hidden shadow-lg">
                     {/* Video placeholder */}
-                    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-purple-900 to-pink-900">
+                    <div className="absolute inset-0 flex items-center justify-center bg-foreground">
                       <Button
                         size="lg"
-                        className="rounded-full w-16 h-16 bg-white hover:bg-gray-100 shadow-xl"
+                        className="rounded-full w-16 h-16 bg-white hover:bg-muted shadow-xl"
                         onClick={() => setIsPlaying(!isPlaying)}
                       >
                         {isPlaying ? (
-                          <Pause className="w-8 h-8 text-gray-900" />
+                          <Pause className="w-8 h-8 text-foreground" />
                         ) : (
-                          <Play className="w-8 h-8 text-gray-900 ml-1" />
+                          <Play className="w-8 h-8 text-foreground ml-1" />
                         )}
                       </Button>
                     </div>
@@ -216,7 +216,7 @@ export default function LessonPage() {
                   <div className="flex gap-2 mt-2 flex-wrap">
                     <Badge variant="outline">📝 Transcript disponibile</Badge>
                     <Badge variant="outline">🎧 Audio disponibile</Badge>
-                    {accessibilityMode && <Badge variant="outline" className="bg-blue-100">♿ Sottotitoli attivi</Badge>}
+                    {accessibilityMode && <Badge variant="outline" className="bg-muted">♿ Sottotitoli attivi</Badge>}
                   </div>
                 </div>
               )}
@@ -224,7 +224,7 @@ export default function LessonPage() {
               {/* Audio Player */}
               {contentMode === "audio" && (
                 <div className="mb-8">
-                  <div className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-lg p-8 text-white text-center">
+                  <div className="bg-foreground rounded-lg p-8 text-background text-center">
                     <Headphones className="w-16 h-16 mx-auto mb-4" />
                     <h3 className="text-xl font-semibold mb-2">Modalità Audio</h3>
                     <p className="text-sm opacity-90 mb-6">Ascolta la lezione mentre fai altro</p>
@@ -264,7 +264,7 @@ export default function LessonPage() {
                     ma una mentalità che mette le persone al centro dell'innovazione.
                   </p>
 
-                  <div className={`bg-purple-50 border-l-4 border-purple-500 p-4 my-6 ${accessibilityMode ? 'p-6 my-8 border-l-8' : ''}`}>
+                  <div className={`bg-muted border-l-4 border-foreground p-4 my-6 ${accessibilityMode ? 'p-6 my-8 border-l-8' : ''}`}>
                     <p className={`font-semibold mb-2 ${accessibilityMode ? 'text-lg mb-4' : ''}`}>💡 CONCETTO CHIAVE</p>
                     <p className={`mb-0 ${accessibilityMode ? 'text-base' : ''}`}>
                       Design Thinking = Processo NON lineare. Non segui steps 1→2→3,
@@ -272,31 +272,31 @@ export default function LessonPage() {
                     </p>
                   </div>
 
-                  <div className={`bg-white border-2 border-gray-200 rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
+                  <div className={`bg-background border-2 border-border rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
                     <h4 className={`text-center mb-4 ${accessibilityMode ? 'text-xl mb-6' : ''}`}>Le 5 Fasi del Design Thinking</h4>
                     <div className="flex flex-wrap justify-center items-center gap-4">
                       {["Empathize", "Define", "Ideate", "Prototype", "Test"].map((step, i) => (
                         <div key={step} className="flex items-center">
-                          <div className={`bg-purple-100 border-2 border-purple-500 rounded-full px-4 py-2 font-semibold ${accessibilityMode ? 'border-4 px-6 py-3 text-lg' : ''}`}>
+                          <div className={`bg-muted border-2 border-foreground rounded-full px-4 py-2 font-semibold ${accessibilityMode ? 'border-4 px-6 py-3 text-lg' : ''}`}>
                             {step}
                           </div>
-                          {i < 4 && <ChevronRight className={`text-gray-400 mx-2 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />}
+                          {i < 4 && <ChevronRight className={`text-muted-foreground/60 mx-2 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />}
                         </div>
                       ))}
                     </div>
-                    <p className={`text-center text-sm text-gray-600 mt-4 ${accessibilityMode ? 'text-base mt-6' : ''}`}>
+                    <p className={`text-center text-sm text-muted-foreground mt-4 ${accessibilityMode ? 'text-base mt-6' : ''}`}>
                       Processo iterativo - puoi tornare indietro in qualsiasi momento
                     </p>
                   </div>
 
                   {/* Audio Option */}
-                  <div className={`bg-blue-50 rounded-lg p-4 my-6 ${accessibilityMode ? 'p-6 my-8' : ''}`}>
+                  <div className={`bg-muted rounded-lg p-4 my-6 ${accessibilityMode ? 'p-6 my-8' : ''}`}>
                     <div className="flex items-center justify-between flex-wrap gap-4">
                       <div className="flex items-center gap-3">
-                        <Headphones className={`text-blue-600 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
+                        <Headphones className={`text-foreground ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
                         <div>
                           <p className={`font-medium ${accessibilityMode ? 'text-lg' : ''}`}>Ascolta questa sezione</p>
-                          <p className="text-sm text-gray-600">Narrazione AI • 3 min</p>
+                          <p className="text-sm text-muted-foreground">Narrazione AI • 3 min</p>
                         </div>
                       </div>
                       <Button size="sm">
@@ -307,17 +307,17 @@ export default function LessonPage() {
                   </div>
 
                   {/* Book Extract - Content Mashup */}
-                  <div className={`bg-amber-50 border-2 border-amber-200 rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
+                  <div className={`bg-muted border-2 border-border rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
                     <div className="flex items-start gap-3">
-                      <BookOpen className={`text-amber-600 flex-shrink-0 mt-1 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
+                      <BookOpen className={`text-foreground flex-shrink-0 mt-1 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
                       <div>
                         <p className={`font-semibold mb-2 ${accessibilityMode ? 'text-lg mb-4' : ''}`}>
                           📚 Approfondimento (Contenuto Casa Editrice)
                         </p>
-                        <p className={`text-sm text-gray-600 mb-3 ${accessibilityMode ? 'text-base mb-4' : ''}`}>
+                        <p className={`text-sm text-muted-foreground mb-3 ${accessibilityMode ? 'text-base mb-4' : ''}`}>
                           Dal libro "Design Thinking for Beginners" di Tim Brown (IDEO)
                         </p>
-                        <blockquote className={`border-l-4 border-amber-500 pl-4 italic text-gray-700 ${accessibilityMode ? 'border-l-8 pl-6 text-base not-italic' : ''}`}>
+                        <blockquote className={`border-l-4 border-foreground pl-4 italic text-muted-foreground ${accessibilityMode ? 'border-l-8 pl-6 text-base not-italic' : ''}`}>
                           "Il Design Thinking è emerso negli anni '60 come metodologia
                           formale per l'innovazione. L'approccio si basa sulla convinzione
                           che i problemi complessi richiedano soluzioni creative che mettano
@@ -331,21 +331,21 @@ export default function LessonPage() {
                   </div>
 
                   {/* External Resources */}
-                  <div className={`border-2 border-gray-200 rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
+                  <div className={`border-2 border-border rounded-lg p-6 my-6 ${accessibilityMode ? 'p-8 my-8 border-4' : ''}`}>
                     <h4 className={`font-semibold mb-4 ${accessibilityMode ? 'text-xl mb-6' : ''}`}>🔗 Risorse Extra</h4>
                     <div className="space-y-3">
-                      <a href="#" className={`flex items-center gap-3 p-3 hover:bg-gray-50 rounded-lg transition-colors ${accessibilityMode ? 'p-4 ring-2 ring-transparent hover:ring-purple-300' : ''}`}>
-                        <FileText className={`text-gray-600 ${accessibilityMode ? 'w-6 h-6' : 'w-5 h-5'}`} />
+                      <a href="#" className={`flex items-center gap-3 p-3 hover:bg-muted rounded-lg transition-colors ${accessibilityMode ? 'p-4 ring-2 ring-transparent hover:ring-foreground/30' : ''}`}>
+                        <FileText className={`text-muted-foreground ${accessibilityMode ? 'w-6 h-6' : 'w-5 h-5'}`} />
                         <div>
                           <p className={`font-medium ${accessibilityMode ? 'text-lg' : ''}`}>Design Thinking Toolkit (IDEO)</p>
-                          <p className="text-sm text-gray-600">PDF • 2 MB</p>
+                          <p className="text-sm text-muted-foreground">PDF • 2 MB</p>
                         </div>
                       </a>
-                      <a href="#" className={`flex items-center gap-3 p-3 hover:bg-gray-50 rounded-lg transition-colors ${accessibilityMode ? 'p-4 ring-2 ring-transparent hover:ring-purple-300' : ''}`}>
-                        <Video className={`text-gray-600 ${accessibilityMode ? 'w-6 h-6' : 'w-5 h-5'}`} />
+                      <a href="#" className={`flex items-center gap-3 p-3 hover:bg-muted rounded-lg transition-colors ${accessibilityMode ? 'p-4 ring-2 ring-transparent hover:ring-foreground/30' : ''}`}>
+                        <Video className={`text-muted-foreground ${accessibilityMode ? 'w-6 h-6' : 'w-5 h-5'}`} />
                         <div>
                           <p className={`font-medium ${accessibilityMode ? 'text-lg' : ''}`}>TED Talk: Tim Brown on Design Thinking</p>
-                          <p className="text-sm text-gray-600">Video • 18 min</p>
+                          <p className="text-sm text-muted-foreground">Video • 18 min</p>
                         </div>
                       </a>
                     </div>
@@ -354,7 +354,7 @@ export default function LessonPage() {
               )}
 
               {/* Quick Quiz */}
-              <div className={`bg-green-50 border-2 border-green-200 rounded-lg p-6 mt-8 ${accessibilityMode ? 'p-8 mt-12 border-4' : ''}`}>
+              <div className={`bg-muted border-2 border-border rounded-lg p-6 mt-8 ${accessibilityMode ? 'p-8 mt-12 border-4' : ''}`}>
                 <h3 className={`font-semibold text-lg mb-4 ${accessibilityMode ? 'text-2xl mb-6' : ''}`}>❓ Verifica la Comprensione</h3>
                 <p className={`mb-4 ${accessibilityMode ? 'text-lg mb-6' : ''}`}>Il Design Thinking è un processo:</p>
 
@@ -364,7 +364,7 @@ export default function LessonPage() {
                       <RadioGroupItem value="linear" id="linear" className="peer sr-only" />
                       <Label
                         htmlFor="linear"
-                        className={`flex items-center gap-3 p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-green-500 peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-purple-500' : ''}`}
+                        className={`flex items-center gap-3 p-4 border-2 border-border rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-foreground peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-foreground' : ''}`}
                       >
                         A. Lineare - segui steps sequenziali
                       </Label>
@@ -373,7 +373,7 @@ export default function LessonPage() {
                       <RadioGroupItem value="iterative" id="iterative" className="peer sr-only" />
                       <Label
                         htmlFor="iterative"
-                        className={`flex items-center gap-3 p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-green-500 peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-purple-500' : ''}`}
+                        className={`flex items-center gap-3 p-4 border-2 border-border rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-foreground peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-foreground' : ''}`}
                       >
                         B. Iterativo - vai avanti/indietro tra fasi
                       </Label>
@@ -382,7 +382,7 @@ export default function LessonPage() {
                       <RadioGroupItem value="random" id="random" className="peer sr-only" />
                       <Label
                         htmlFor="random"
-                        className={`flex items-center gap-3 p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-green-500 peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-purple-500' : ''}`}
+                        className={`flex items-center gap-3 p-4 border-2 border-border rounded-lg cursor-pointer hover:bg-white peer-data-[state=checked]:border-foreground peer-data-[state=checked]:bg-white ${accessibilityMode ? 'p-6 border-4 text-lg ring-2 ring-transparent focus-within:ring-foreground' : ''}`}
                       >
                         C. Randomico - fai quello che vuoi
                       </Label>
@@ -391,12 +391,12 @@ export default function LessonPage() {
                 </RadioGroup>
 
                 {quizAnswer === "iterative" && (
-                  <div className={`mt-4 p-4 bg-white rounded-lg border-2 border-green-500 ${accessibilityMode ? 'mt-6 p-6 border-4' : ''}`}>
+                  <div className={`mt-4 p-4 bg-white rounded-lg border-2 border-foreground ${accessibilityMode ? 'mt-6 p-6 border-4' : ''}`}>
                     <div className="flex items-start gap-3">
-                      <CheckCircle2 className={`text-green-500 flex-shrink-0 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
+                      <CheckCircle2 className={`text-foreground flex-shrink-0 ${accessibilityMode ? 'w-8 h-8' : 'w-6 h-6'}`} />
                       <div>
-                        <p className={`font-semibold text-green-900 ${accessibilityMode ? 'text-xl mb-3' : ''}`}>✅ Corretto!</p>
-                        <p className={`text-sm text-gray-700 mt-1 ${accessibilityMode ? 'text-base mt-2' : ''}`}>
+                        <p className={`font-semibold text-foreground ${accessibilityMode ? 'text-xl mb-3' : ''}`}>✅ Corretto!</p>
+                        <p className={`text-sm text-muted-foreground mt-1 ${accessibilityMode ? 'text-base mt-2' : ''}`}>
                           Esattamente. Il Design Thinking è un processo iterativo dove
                           puoi tornare indietro e ripetere fasi basandoti sugli insights ottenuti.
                         </p>
@@ -406,12 +406,12 @@ export default function LessonPage() {
                 )}
 
                 {quizAnswer && quizAnswer !== "iterative" && (
-                  <div className={`mt-4 p-4 bg-white rounded-lg border-2 border-red-500 ${accessibilityMode ? 'mt-6 p-6 border-4' : ''}`}>
+                  <div className={`mt-4 p-4 bg-white rounded-lg border-2 border-destructive ${accessibilityMode ? 'mt-6 p-6 border-4' : ''}`}>
                     <div className="flex items-start gap-3">
                       <div className={`flex-shrink-0 ${accessibilityMode ? 'text-2xl' : 'text-xl'}`}>❌</div>
                       <div>
-                        <p className={`font-semibold text-red-900 ${accessibilityMode ? 'text-xl mb-3' : ''}`}>Non proprio...</p>
-                        <p className={`text-sm text-gray-700 mt-1 ${accessibilityMode ? 'text-base mt-2' : ''}`}>
+                        <p className={`font-semibold text-destructive ${accessibilityMode ? 'text-xl mb-3' : ''}`}>Non proprio...</p>
+                        <p className={`text-sm text-muted-foreground mt-1 ${accessibilityMode ? 'text-base mt-2' : ''}`}>
                           Riprova! Pensa alle parole chiave menzionate nella lezione.
                         </p>
                       </div>
@@ -425,7 +425,7 @@ export default function LessonPage() {
                 <Button variant="outline" disabled={currentSection === 1} onClick={() => setCurrentSection(prev => prev - 1)}>
                   ← Sezione Precedente
                 </Button>
-                <div className="text-sm text-gray-600">
+                <div className="text-sm text-muted-foreground">
                   Sezione {currentSection} di 4
                 </div>
                 <Button onClick={() => setCurrentSection(prev => Math.min(prev + 1, 4))}>
@@ -437,12 +437,12 @@ export default function LessonPage() {
           </Card>
 
           {/* Progress Indicator */}
-          <Card className="bg-gradient-to-r from-purple-50 to-pink-50 border-purple-200">
+          <Card className="bg-muted border-border">
             <CardContent className="p-6">
               <div className="flex items-center justify-between flex-wrap gap-4">
                 <div>
-                  <p className="font-semibold text-gray-900 mb-1">Ottimo lavoro! 👏</p>
-                  <p className="text-sm text-gray-600">
+                  <p className="font-semibold text-foreground mb-1">Ottimo lavoro! 👏</p>
+                  <p className="text-sm text-muted-foreground">
                     Hai completato {currentSection} di 4 sezioni di questa lezione
                   </p>
                 </div>

--- a/apps/web/src/app/(presentation)/layout.tsx
+++ b/apps/web/src/app/(presentation)/layout.tsx
@@ -1,6 +1,6 @@
 export default function PresentationLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="presentation-theme bg-[hsl(240,10%,4%)] text-[hsl(30,6%,90%)] min-h-screen overflow-hidden">
+    <div className="presentation-theme bg-[hsl(240,10%,4%)] text-[hsl(30,6%,90%)] min-h-screen overflow-hidden pt-8">
       {children}
     </div>
   )

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -48,60 +48,76 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+  --shadow-2xs: var(--shadow-2xs);
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
 }
 
 :root {
-  --radius: 0.75rem;
+  --radius: 0rem;
 
-  /* Neo-Academic Luxury Palette */
-  --background: 252 100% 99%;
-  --foreground: 240 15% 12%;
+  /* B&W Sketchpad Palette */
+  --background: 0 0% 100%;
+  --foreground: 0 0% 8%;
 
-  /* Brand Colors - Deep Indigo & Warm Amber */
-  --indigo: 238 45% 28%;
-  --amber: 38 92% 58%;
-  --sage: 145 25% 45%;
-  --gold: 43 96% 56%;
+  /* Brand Colors — Grayscale */
+  --indigo: 0 0% 15%;
+  --amber: 0 0% 45%;
+  --sage: 0 0% 60%;
+  --gold: 0 0% 35%;
 
   --card: 0 0% 100%;
-  --card-foreground: 240 15% 12%;
+  --card-foreground: 0 0% 8%;
 
   --popover: 0 0% 100%;
-  --popover-foreground: 240 15% 12%;
+  --popover-foreground: 0 0% 8%;
 
-  --primary: 238 45% 28%;
+  --primary: 0 0% 12%;
   --primary-foreground: 0 0% 100%;
 
-  --secondary: 38 92% 58%;
-  --secondary-foreground: 240 15% 12%;
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 12%;
 
-  --muted: 240 10% 96%;
-  --muted-foreground: 240 8% 46%;
+  --muted: 0 0% 96%;
+  --muted-foreground: 0 0% 45%;
 
-  --accent: 145 25% 45%;
-  --accent-foreground: 0 0% 100%;
+  --accent: 0 0% 96%;
+  --accent-foreground: 0 0% 12%;
 
   --destructive: 0 84% 60%;
   --destructive-foreground: 0 0% 100%;
 
-  --border: 240 10% 90%;
-  --input: 240 10% 90%;
-  --ring: 238 45% 28%;
+  --border: 0 0% 90%;
+  --input: 0 0% 90%;
+  --ring: 0 0% 40%;
 
-  --chart-1: 238 45% 28%;
-  --chart-2: 38 92% 58%;
-  --chart-3: 145 25% 45%;
-  --chart-4: 43 96% 56%;
-  --chart-5: 280 50% 65%;
+  --chart-1: 0 0% 15%;
+  --chart-2: 0 0% 35%;
+  --chart-3: 0 0% 55%;
+  --chart-4: 0 0% 70%;
+  --chart-5: 0 0% 85%;
 
-  --sidebar: 0 0% 100%;
-  --sidebar-foreground: 240 15% 12%;
-  --sidebar-primary: 238 45% 28%;
+  --sidebar: 0 0% 98%;
+  --sidebar-foreground: 0 0% 8%;
+  --sidebar-primary: 0 0% 12%;
   --sidebar-primary-foreground: 0 0% 100%;
-  --sidebar-accent: 240 10% 96%;
-  --sidebar-accent-foreground: 240 15% 12%;
-  --sidebar-border: 240 10% 90%;
-  --sidebar-ring: 238 45% 28%;
+  --sidebar-accent: 0 0% 96%;
+  --sidebar-accent-foreground: 0 0% 12%;
+  --sidebar-border: 0 0% 90%;
+  --sidebar-ring: 0 0% 40%;
+
+  /* Shadow system — geometric 4px offset (sketchpad style) */
+  --shadow-2xs: 4px 4px 0px 0px hsl(0 0% 40% / 0.07);
+  --shadow-xs: 4px 4px 0px 0px hsl(0 0% 40% / 0.07);
+  --shadow-sm: 4px 4px 0px 0px hsl(0 0% 40% / 0.15), 4px 1px 2px -1px hsl(0 0% 40% / 0.15);
+  --shadow-md: 4px 4px 0px 0px hsl(0 0% 40% / 0.15), 4px 2px 4px -1px hsl(0 0% 40% / 0.15);
+  --shadow-lg: 4px 4px 0px 0px hsl(0 0% 40% / 0.15), 4px 4px 6px -1px hsl(0 0% 40% / 0.15);
+  --shadow-xl: 4px 4px 0px 0px hsl(0 0% 40% / 0.15), 4px 8px 10px -1px hsl(0 0% 40% / 0.15);
+  --shadow-2xl: 4px 4px 0px 0px hsl(0 0% 40% / 0.38);
 }
 
 @layer base {
@@ -154,7 +170,7 @@
   }
 
   .glass-effect {
-    @apply backdrop-blur-xl bg-white/80 border border-white/20 shadow-2xl;
+    @apply backdrop-blur-xl bg-white/80 border border-black/5 shadow-2xl;
   }
 
   .editorial-grid {

--- a/apps/web/src/components/business-plan/bp-sidebar.tsx
+++ b/apps/web/src/components/business-plan/bp-sidebar.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 import {
   LayoutDashboard, CalendarDays, Briefcase, TrendingUp, Wallet,
   Monitor, Target, AlertTriangle, Handshake, Map, BarChart3,
-  Globe, Rocket
+  Globe, Rocket, ArrowLeft
 } from "lucide-react"
 
 const sections = [
@@ -31,6 +31,14 @@ export function BPSidebar() {
   return (
     <aside className="w-64 shrink-0 border-r border-border bg-card hidden lg:block">
       <div className="sticky top-8 h-[calc(100vh-2rem)] overflow-y-auto p-4">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Torna all&apos;Hub
+        </Link>
+
         <div className="mb-6">
           <h3 className="font-display text-lg font-semibold">Education Hub</h3>
           <p className="text-xs text-muted-foreground">Business Plan 2026-2030</p>

--- a/apps/web/src/components/business-plan/platform-costs.tsx
+++ b/apps/web/src/components/business-plan/platform-costs.tsx
@@ -293,10 +293,10 @@ export function PlatformCosts() {
                         <td className="py-2 px-2 font-medium">{c.service}</td>
                         <td className="py-2 px-2">
                           <span className={`text-xs px-1.5 py-0.5 rounded-full ${
-                            c.category === 'AI/ML' ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300' :
-                            c.category === 'Infrastruttura' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300' :
-                            c.category === 'Blockchain' ? 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300' :
-                            'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300'
+                            c.category === 'AI/ML' ? 'bg-muted text-foreground' :
+                            c.category === 'Infrastruttura' ? 'bg-muted text-foreground' :
+                            c.category === 'Blockchain' ? 'bg-muted text-foreground' :
+                            'bg-muted text-foreground'
                           }`}>
                             {c.category}
                           </span>
@@ -422,9 +422,9 @@ export function PlatformCosts() {
                         <td className="py-2 px-2 font-medium">{o.strategy}</td>
                         <td className="py-2 px-2">
                           <span className={`text-xs px-1.5 py-0.5 rounded-full ${
-                            o.area === 'AI/ML' ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300' :
-                            o.area === 'Blockchain' ? 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300' :
-                            'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300'
+                            o.area === 'AI/ML' ? 'bg-muted text-foreground' :
+                            o.area === 'Blockchain' ? 'bg-muted text-foreground' :
+                            'bg-muted text-foreground'
                           }`}>
                             {o.area}
                           </span>

--- a/apps/web/src/components/hub/hub-navbar.tsx
+++ b/apps/web/src/components/hub/hub-navbar.tsx
@@ -29,19 +29,26 @@ function getActiveAreaId(pathname: string): string | null {
 
 export function HubNavbar() {
   const pathname = usePathname()
-
-  // Hide on presentation pages (full-screen immersive)
-  if (pathname.startsWith("/presentation")) return null
-
   const activeId = getActiveAreaId(pathname)
+  const isPresentation = pathname.startsWith("/presentation")
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-[60] h-8 glass-effect border-b border-border/30">
+    <nav className={cn(
+      "fixed top-0 left-0 right-0 z-[60] h-8 border-b",
+      isPresentation
+        ? "bg-[hsl(240,10%,6%)]/95 backdrop-blur-sm border-white/10"
+        : "glass-effect border-border/30"
+    )}>
       <div className="h-full max-w-screen-2xl mx-auto px-4 flex items-center justify-between gap-4">
         {/* Left: Logo mini */}
         <Link
           href="/"
-          className="shrink-0 font-display text-sm font-semibold tracking-tight text-foreground hover:text-primary transition-colors"
+          className={cn(
+            "shrink-0 font-display text-sm font-semibold tracking-tight transition-colors",
+            isPresentation
+              ? "text-white/80 hover:text-white"
+              : "text-foreground hover:text-primary"
+          )}
         >
           EH
         </Link>
@@ -56,9 +63,13 @@ export function HubNavbar() {
                 href={area.href}
                 className={cn(
                   "px-3 py-0.5 rounded-full text-[11px] font-medium transition-all",
-                  isActive
-                    ? "bg-foreground text-background"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  isPresentation
+                    ? isActive
+                      ? "bg-white/20 text-white"
+                      : "text-white/40 hover:text-white/70 hover:bg-white/10"
+                    : isActive
+                      ? "bg-foreground text-background"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
                 )}
               >
                 {area.label}
@@ -67,9 +78,9 @@ export function HubNavbar() {
           })}
         </div>
 
-        {/* Right: Breadcrumb */}
+        {/* Right: Breadcrumb (hidden on presentation) */}
         <div className="hidden md:block">
-          <HubBreadcrumb />
+          {!isPresentation && <HubBreadcrumb />}
         </div>
       </div>
     </nav>

--- a/apps/web/src/components/marketing/areas-section.tsx
+++ b/apps/web/src/components/marketing/areas-section.tsx
@@ -24,8 +24,8 @@ const areas = [
     icon: Palette,
     description: "UX/UI Design, AI Experience Design e Human-Robot Interaction per creare esperienze memorabili tra umani, schermi e macchine.",
     courses: ["UX/UI Design", "AI Experience Design", "Robotics & HRI", "Product Design"],
-    color: "from-purple-500 to-pink-600",
-    bgColor: "bg-purple-50",
+    color: "from-neutral-700 to-neutral-900",
+    bgColor: "bg-muted",
     stats: "350 studenti attivi"
   },
   {
@@ -34,8 +34,8 @@ const areas = [
     icon: Code,
     description: "Full-Stack Development, AI Engineering, IoT e Data Science per costruire i sistemi intelligenti del futuro.",
     courses: ["Full-Stack Dev", "AI Engineering", "IoT Systems", "Data Science"],
-    color: "from-blue-500 to-cyan-600",
-    bgColor: "bg-blue-50",
+    color: "from-neutral-500 to-neutral-700",
+    bgColor: "bg-muted",
     stats: "569 studenti attivi"
   },
   {
@@ -44,8 +44,8 @@ const areas = [
     icon: TrendingUp,
     description: "Product Management, AI Strategy e Smart Operations per guidare la trasformazione digitale nelle aziende.",
     courses: ["Product Mgmt", "AI Strategy", "Smart Business", "Growth Marketing"],
-    color: "from-amber-500 to-orange-600",
-    bgColor: "bg-amber-50",
+    color: "from-neutral-400 to-neutral-600",
+    bgColor: "bg-muted",
     stats: "337 studenti attivi"
   }
 ]

--- a/apps/web/src/components/presentation/presentation-deck.tsx
+++ b/apps/web/src/components/presentation/presentation-deck.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react"
 import { AnimatePresence, motion } from "framer-motion"
-import Link from "next/link"
-import { X, ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 import { Slide01 } from "./slides/slide-01"
 import { Slide02 } from "./slides/slide-02"
 import { Slide03 } from "./slides/slide-03"
@@ -84,16 +83,7 @@ export function PresentationDeck() {
   }
 
   return (
-    <div className="relative w-full h-screen overflow-hidden">
-      {/* Exit button */}
-      <Link
-        href="/"
-        className="fixed top-4 left-4 z-50 flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/20 text-white/80 hover:text-white text-sm transition-all backdrop-blur-sm"
-      >
-        <X className="h-4 w-4" />
-        <span className="hidden sm:inline">Esci</span>
-      </Link>
-
+    <div className="relative w-full h-[calc(100vh-2rem)] overflow-hidden">
       {/* Slide content */}
       <AnimatePresence mode="wait" custom={direction}>
         <motion.div
@@ -111,7 +101,7 @@ export function PresentationDeck() {
       </AnimatePresence>
 
       {/* Progress track (right side) */}
-      <div className="fixed right-4 top-1/2 -translate-y-1/2 z-40 flex flex-col gap-2">
+      <div className="absolute right-4 top-1/2 -translate-y-1/2 z-40 flex flex-col gap-2">
         {slides.map((_, i) => (
           <button
             key={i}
@@ -128,7 +118,7 @@ export function PresentationDeck() {
       </div>
 
       {/* Bottom navigation */}
-      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-4">
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-4">
         <button onClick={prev} disabled={current === 0} className="p-2 text-white/50 hover:text-white disabled:opacity-20 transition-colors">
           <ChevronLeft className="h-5 w-5" />
         </button>

--- a/apps/web/src/components/presentation/slides/slide-01.tsx
+++ b/apps/web/src/components/presentation/slides/slide-01.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide01({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Scenario

--- a/apps/web/src/components/presentation/slides/slide-02.tsx
+++ b/apps/web/src/components/presentation/slides/slide-02.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide02({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Il Problema

--- a/apps/web/src/components/presentation/slides/slide-03.tsx
+++ b/apps/web/src/components/presentation/slides/slide-03.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide03({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />L&apos;Obiettivo

--- a/apps/web/src/components/presentation/slides/slide-04.tsx
+++ b/apps/web/src/components/presentation/slides/slide-04.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.12 } } }
 
 export function Slide04({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Il Paradigma

--- a/apps/web/src/components/presentation/slides/slide-05.tsx
+++ b/apps/web/src/components/presentation/slides/slide-05.tsx
@@ -20,7 +20,7 @@ const modelli = [
 
 export function Slide05({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />L&apos;Accademia

--- a/apps/web/src/components/presentation/slides/slide-06.tsx
+++ b/apps/web/src/components/presentation/slides/slide-06.tsx
@@ -13,7 +13,7 @@ export function Slide06({ skipReveal }: { skipReveal?: boolean }) {
     { num: "05", text: "Community integrata — forum, mentorship tra pari, rete alumni" },
   ]
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />La Piattaforma

--- a/apps/web/src/components/presentation/slides/slide-07.tsx
+++ b/apps/web/src/components/presentation/slides/slide-07.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide07({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />La Casa Editrice

--- a/apps/web/src/components/presentation/slides/slide-08.tsx
+++ b/apps/web/src/components/presentation/slides/slide-08.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide08({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />La Convergenza

--- a/apps/web/src/components/presentation/slides/slide-09.tsx
+++ b/apps/web/src/components/presentation/slides/slide-09.tsx
@@ -18,7 +18,7 @@ export function Slide09({ skipReveal }: { skipReveal?: boolean }) {
     { title: "Gruppo Editoriale", desc: "Catalogo → Formazione → Dati → Scelte editoriali" },
   ]
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Ecosistema di Business

--- a/apps/web/src/components/presentation/slides/slide-10.tsx
+++ b/apps/web/src/components/presentation/slides/slide-10.tsx
@@ -6,7 +6,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function Slide10({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />La Proposta

--- a/apps/web/src/components/presentation/slides/slide-b2b.tsx
+++ b/apps/web/src/components/presentation/slides/slide-b2b.tsx
@@ -7,7 +7,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.12 } } }
 
 export function SlideB2B({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />B2B & Corporate

--- a/apps/web/src/components/presentation/slides/slide-hard-soft.tsx
+++ b/apps/web/src/components/presentation/slides/slide-hard-soft.tsx
@@ -7,7 +7,7 @@ const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.15 } } }
 
 export function SlideHardSoft({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Il Metodo

--- a/apps/web/src/components/presentation/slides/slide-sources.tsx
+++ b/apps/web/src/components/presentation/slides/slide-sources.tsx
@@ -21,7 +21,7 @@ const sources = [
 
 export function SlideSources({ skipReveal }: { skipReveal?: boolean }) {
   return (
-    <div className="h-screen flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
+    <div className="h-full flex flex-col justify-center px-8 md:px-16 lg:px-24 overflow-y-auto">
       <motion.div variants={stagger} initial={skipReveal ? "show" : "hidden"} animate="show" className="max-w-5xl mx-auto w-full">
         <motion.div variants={reveal} className="text-xs uppercase tracking-[0.3em] text-[hsl(37,88%,55%)] mb-6 flex items-center gap-3">
           <span className="w-8 h-px bg-[hsl(37,88%,55%)]" />Appendice

--- a/apps/web/src/components/shared/course-card.tsx
+++ b/apps/web/src/components/shared/course-card.tsx
@@ -283,6 +283,6 @@ export const createCourseStats = {
     icon: Star,
     label: "Rating",
     value,
-    iconClassName: "fill-amber-400 text-amber-400"
+    iconClassName: "fill-muted-foreground text-muted-foreground"
   })
 }


### PR DESCRIPTION
## Summary
- Migrazione completa del design system a bianco e nero con estetica sketchpad (angoli vivi, ombre geometriche 4px)
- Variabili CSS root aggiornate: colori brand/semantici/chart/sidebar → grayscale, `--radius: 0rem`, nuovo shadow system
- Fix ~30 classi Tailwind hardcoded (purple, blue, amber, green) sostituite con token semantici
- Presentation theme preservato intatto con i colori originali
- Navbar hub visibile su pagine presentazione (variante dark)

## Files modificati (23)
- `globals.css` — variabili CSS, shadows, radius, glass-effect
- `platform-costs.tsx`, `lessons/[id]/page.tsx`, `course-card.tsx`, `areas-section.tsx`, `dashboard/page.tsx` — fix Tailwind utilities
- `hub-navbar.tsx`, `bp-sidebar.tsx`, `presentation-deck.tsx`, slides — navigation improvements

## Cosa NON cambia
- Font (Cormorant + Inter)
- Presentation theme (`.presentation-theme`)
- Colori hex esterni (LinkedIn, Figma)
- Layout e struttura pagine
- Animazioni Framer Motion

## Test plan
- [x] `@edu-hub/web` build senza errori (41/41 pagine)
- [ ] Verifica visiva: Hub (`/`), Business Plan (`/business-plan`), Marketing (`/home`), Platform (`/dashboard`, `/lessons/1`)
- [ ] Verifica che `/presentation` resti colorata
- [ ] Controllare ombre geometriche 4px sulle card
- [ ] Controllare angoli vivi (0 radius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)